### PR TITLE
feature(func-style): allow arrow function expressions

### DIFF
--- a/base.js
+++ b/base.js
@@ -28,5 +28,6 @@ module.exports = {
         "no-constant-condition": ["error", { "checkLoops": false }],
         "quotes": [2, "single", "avoid-escape"],
         "jsdoc/require-description-complete-sentence": 0,
+        "func-style": ["error", "declaration", { "allowArrowFunctions": true }]
     }
 };


### PR DESCRIPTION
In favor for readability and current standards I would prefer to use `arrow functions` where I can.

This has some benefits:
e.g.

**shorter stateless components**
```js
const CoolButton = { text } => (
  <button className="cool-button">{ text }</button>
);
```
vs
```js
function CoolButton({ text }) {
  return (
    <button className="cool-button">{ text } </button>
  );
}
```

**redux**
```js
const mapDispatchToProps = dispatch => ({
  handleSetActive: bindActionCreators(setActive, dispatch)
});
```
